### PR TITLE
Integrate Companion 1 Docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "themes/adidoks"]
 	path = themes/adidoks
 	url = https://github.com/ES-Alexander/adidoks.git
+[submodule "Companion Docker"]
+	path = content/software/companion/1.0
+	url = https://github.com/bluerobotics/ardusub-zola.git
+	branch = companion-1.0

--- a/content/software/_index.md
+++ b/content/software/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Software"
+description = "Software documentation."
+date = 2021-10-21T01:00:00+00:00
+updated = 2021-10-21T01:00:00+00:00
+sort_by = "weight"
+weight = 1
+template = "docs/section.html"
++++

--- a/content/software/companion/_index.md
+++ b/content/software/companion/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Companion Versions"
+description = "Documentation for the different Companion Versions."
+date = 2021-10-20T23:59:00+00:00
+template = "docs/section.html"
+sort_by = "weight"
+weight = 1
+draft = false
++++


### PR DESCRIPTION
- Covers the existing companion 1 google doc (except the first page)
- Output at `docs.bluerobotics.com/ardusub-zola/software/companion/1.0`