### PR TITLE
update name: BlueOS Docker -> BlueOS

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "BlueOS Docker"
+title = "BlueOS"
 description = "Documentation for the BlueOS Docker software (replaces Companion)."
 date = 2021-10-20T20:30:00+00:00
 template = "docs/section.html"


### PR DESCRIPTION
Docker is an implementation detail, and likely makes the name more confusing and 'scary' for users than it needs to be.