### PR TITLE
templates: shortcodes: fix mermaid integration

### DIFF
--- a/templates/shortcodes/mermaid.html
+++ b/templates/shortcodes/mermaid.html
@@ -18,7 +18,7 @@
      it will replace the content of those divs with the generated svg -->
 <script type="module">
  // sourced from https://unpkg.com/mermaid@9/dist/mermaid.esm.min.mjs
- import mermaid from '/js/mermaid.esm.min.mjs';
+ import mermaid from '{{get_url(path="/js/mermaid.esm.min.mjs")}}';
 
  let darkMode = (
      localStorage.getItem('theme') === 'dark'


### PR DESCRIPTION
Absolute links need to use `base_url`, which is corrected for with the `get_url` macro.

Closes #44 