### PR TITLE
getting-started: add alias to old name/structure

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -6,6 +6,8 @@ template = "docs/page.html"
 sort_by = "weight"
 weight = 20
 draft = false
+aliases = ['/software/companion/1.0/configuration']
+
 [extra]
 lead = ''
 toc = true


### PR DESCRIPTION
Old link is pointed to in BlueOS 1.0, so needs to redirect to the correct page in the current structure.