### PR TITLE
BlueOS-1.1: advanced-usage: fix broken alias

### DIFF
--- a/advanced-usage/index.md
+++ b/advanced-usage/index.md
@@ -6,12 +6,13 @@ template = "docs/page.html"
 sort_by = "weight"
 weight = 30
 draft = false
+aliases = ['/software/onboard/BlueOS-latest/advanced-usage']
+
 [extra]
 lead = ''
 toc = true
 top = false
 link_base = "https://github.com/bluerobotics/BlueOS-docker/tree/1.1.0-beta.16/core"
-aliases = ['/software/onboard/BlueOS-latest/advanced-usage']
 +++
 
 ## General Information


### PR DESCRIPTION
It was accidentally in the `[extra]` section, which doesn't work.