### PR TITLE
workflows: fix CI - restore Sync Submodules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,11 @@
 name: Deploy to S3
 
 on:
-  schedule:
-    - cron: '10 * * * *'
-  workflow_dispatch:
   push:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Sync Submodules"]
+    types: [completed]
 
 jobs:
   build:
@@ -19,10 +20,6 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v3
-
-      - name: Update submodules to latest commit
-        run: |
-          git submodule update --init --recursive --remote
 
       - name: Run Zola
         uses: shalzz/zola-deploy-action@v0.16.1-1

--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -1,0 +1,28 @@
+on:
+  schedule:
+    # Run everyday at 11:00 UTC
+    - cron:  '0 11 * * *'
+  # Allows you to run this workflow manually from the Actions tab or through HTTP API
+  workflow_dispatch:
+
+name: Sync Submodules
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Git submodule update
+      run: |
+        git submodule update --init --recursive --remote
+
+    - name: Commit update
+      run: |
+        git config --global user.name 'Git bot'
+        git config --global user.email 'bot@noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git commit -am "submodules: Updated references" && git push || echo "No changes to commit"


### PR DESCRIPTION
CI isn't running for BlueOS-deploy. Hopefully this will make it run on schedule, or at least be manually triggerable from workflow dispatch.