### PR TITLE
main: CI fix (attempt)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,6 +5,8 @@ on:
   workflow_run:
     workflows: ["Sync Submodules"]
     types: [completed]
+    branches:
+      - 'main'
 
 name: Test and Deploy
 jobs:

--- a/.github/workflows/fake-deploy.yml
+++ b/.github/workflows/fake-deploy.yml
@@ -1,0 +1,13 @@
+# hack to allow manually triggering the `BlueOS-deploy` branch version of this workflow
+name: Deploy to S3
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  print-irrelevance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print workflow irrelevance
+        run: echo This is only here for BlueOS deploy to be able to run properly


### PR DESCRIPTION
- [x] Avoid running "Test and Deploy" when a Sync Submodules workflow completes in some other branch
- [x] Adds a fake "Deploy to S3" workflow to hopefully allow manually triggering the one in the `BlueOS-deploy` branch