### PR TITLE
[main] add initial Cockpit docs

### DIFF
--- a/.github/workflows/check-trailing-spaces.yml
+++ b/.github/workflows/check-trailing-spaces.yml
@@ -26,6 +26,6 @@ jobs:
           if [[ $FILE == *.md ]]; then
             echo "Checking file $FILE"
             git diff FETCH_HEAD..HEAD -- $FILE | grep -P '^\+' | grep -P '\s+$' && \
-              echo "Trailing spaces found in $FILE" && exit 1
+              echo "Trailing spaces found in $FILE" && exit 1 || :;
           fi
         done

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,7 @@
 	path = content/integrations
 	url = https://github.com/bluerobotics/ardusub-zola
 	branch = Integrations
+[submodule "content/software/control-station/Cockpit-0.0"]
+	path = content/software/control-station/Cockpit-0.0
+	url = https://github.com/bluerobotics/ardusub-zola
+	branch = Cockpit-0.0

--- a/content/software/control-station/_index.md
+++ b/content/software/control-station/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Control Station"
+description = "versioned documentation for the different control station softwares."
+date = 2023-08-26T00:50:00+11:00
+template = "docs/section.html"
+sort_by = "weight"
+weight = 20
+draft = false
++++


### PR DESCRIPTION
Add Cockpit docs at `https://docs.bluerobotics.com/ardusub-zola/software/control-station/Cockpit-0.0`.