### PR TITLE
[BlueOS-deploy] Add initial Cockpit docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 	path = content/integrations
 	url = https://github.com/bluerobotics/ardusub-zola
 	branch = Integrations
+[submodule "content/extensions/cockpit/0.0"]
+	path = content/extensions/cockpit/0.0
+	url = https://github.com/bluerobotics/ardusub-zola
+	branch = Cockpit-0.0

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Docs"
-description = "ArduSub documentation."
+description = "BlueOS documentation."
 date = 2021-10-20T17:00:00+00:00
 updated = 2021-10-20T17:00:00+00:00
 sort_by = "weight"

--- a/content/extensions/_index.md
+++ b/content/extensions/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Extensions"
+description = "BlueOS Extensions documentation."
+date = 2023-08-31T08:10:00+10:00
+updated = 2023-08-31T08:10:00+10:00
+sort_by = "weight"
+weight = 1
+template = "docs/section.html"
++++

--- a/content/extensions/cockpit/_index.md
+++ b/content/extensions/cockpit/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Cockpit"
+description = "Versioned documentation for the Cockpit BlueOS extension."
+date = 2023-08-31T08:15:00+10:00
+template = "docs/versions-section.html"
+sort_by = "weight"
+weight = 10
+draft = false
++++


### PR DESCRIPTION
Adds Cockpit docs to `https://blueos.cloud/docs/extensions/cockpit/0.0`.

I'm a bit unsure whether we want to include this here (since it then opens the door to other extensions being documented in the BlueOS docs), or if Cockpit will have its own website where its docs can be hosted.