### PR TITLE
[BlueOS-devel] improve various docs

### DIFF
--- a/advanced-usage/index.md
+++ b/advanced-usage/index.md
@@ -112,7 +112,7 @@ easily connect to it from a phone
 
 ##### Internet Status and Management
 
-- See whether the vehicle is connected to the internet
+- See whether the vehicle is connected to the internet (updates every 20 seconds)
 
 {{ easy_image(src="internet", center=true, width=50) }}
 {% pirate() %}

--- a/advanced-usage/index.md
+++ b/advanced-usage/index.md
@@ -467,13 +467,15 @@ For making connections to the autopilot, see [MAVLink Endpoints](#mavlink-endpoi
 {% end %}
 {{ easy_image(src="serial-bridges", width=600, class="pirate") }}
 {% pirate() %}
-- NOTE: UDP-based systems do not guarantee packet delivery or sequential alignment
+- **NOTE:** UDP-based systems do not guarantee packet delivery or sequential alignment
 - Bridges to the [Control Station Computer](@/hardware/required/control-computer/index.md)
   will generally use the localhost IP `0.0.0.0`, which creates a UDP server that waits
   for a UDP client on the control computer to connect to it
    - other IP addesses create a UDP client on the onboard computer, which expects the
      serial device to initiate communication before the connected UDP server (on the
      control computer) can respond
+   - **NOTE:** a client should communicate with the server at least once every 10 seconds
+     to avoid being disconnected
 - Bridges to internal programs can use the loopback IP `127.0.0.1`, which creates a
   local server
 {% end %}

--- a/advanced-usage/index.md
+++ b/advanced-usage/index.md
@@ -52,8 +52,11 @@ When you first open BlueOS, you'll see a window like the following:
 #### Header: Indicators and BlueOS Configuration
 
 On the left side of the header there is space for widgets, which can be accessed by
-right clicking and selecting the desired widgets to display. This system is very new,
-so the available widget options are currently quite limited.
+right clicking and selecting the desired widgets to display. Widgets can be reordered
+by clicking and dragging.
+
+There are currently widgets available for displaying the CPU and Disk (storage) usage
+as percentages, which are periodically updated during operation.
 
 {{ easy_image(src="widgets", width=300) }}
 

--- a/advanced-usage/index.md
+++ b/advanced-usage/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Advanced Usage"
 description = "BlueOS advanced usage documentation."
-date = 2023-03-08T12:30:00+11:00
+date = 2023-12-04T19:00:00+11:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 30
@@ -668,11 +668,20 @@ Developers can install custom extensions as relevant.
 
 - the vehicle name makes it easier to determine which vehicle you are connected to
 - changing the mDNS hostname changes the address you connect to for the browser interface
-    - ethernet tether -> [http://custom.local](http://custom.local)
+    - wired connection (ethernet tether / USB-OTG) -> [http://custom.local](http://custom.local)
     - wifi connection -> [http://custom-wifi.local](http://custom-wifi.local)
     - BlueOS hotspot -> [http://custom-hotspot.local](http://custom-hotspot.local)
-    - [http://blueos.local](http://blueos.local) will still be available for direct ethernet
-    connections, as a fallback in case the custom name is forgotten
+    - [http://blueos.local](http://blueos.local) will still be available for wired connections,
+    as a fallback in case the custom name is forgotten
+    - [http://blueos-avahi.local](http://blueos-avahi.local) is broadcast to all interfaces,
+    for connecting when you're not sure which interface(s) are available
+    - IP addresses are always available for
+    [the interfaces they're configured for](#wired-network-management-ethernet-usb-otg), but
+    they're less intuitive to remember than mDNS names
+    - **NOTE:** mDNS is available on most modern operating systems, but
+        - for Windows older than Windows 10, [install Bonjour](https://support.apple.com/kb/dl999)
+        - for Linux run `avahi-discover` on the terminal to see if the avahi service is running
+           - For reference: [Debian](https://wiki.debian.org/Avahi), [Arch](https://wiki.archlinux.org/title/avahi)
 
 {{ easy_image(src="theme-name-mdns", width=400, center=true) }}
 

--- a/development/bootstrap/index.md
+++ b/development/bootstrap/index.md
@@ -1,7 +1,7 @@
 +++
 title = "BlueOS-bootstrap"
 description = "BlueOS-bootstrap development documentation."
-date = 2023-06-02T18:30:00+11:00
+date = 2023-12-04T19:30:00+11:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 20
@@ -27,6 +27,10 @@ BlueOS is set up with a [GitHub Action](https://docs.github.com/en/actions) that
 If you want to make use of that functionality you'll need a [DockerHub](https://hub.docker.com) account, and will need to specify your DockerHub username (`DOCKER_USERNAME`) and password (`DOCKER_PASSWORD`) in your fork's [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 
 ## Updating
+
+{% warning() %}
+BlueOS-bootstrap is a critical component of running BlueOS, and can significantly affect the system stability. It should only be updated when necessary, and preferably at times where the onboard computer hardware is accessible in case something goes wrong. For normal users it is strongly recommended to only update BlueOS-bootstrap to match stable releases of BlueOS, and even then only if there is a known issue an update is expected to fix or improve.
+{% end %}
 
 BlueOS-bootstrap versions are built at the same time as BlueOS-core versions, and they get bundled together in the Raspberry Pi images that can be flashed onto an SD card to install BlueOS onto it. For official BlueOS releases it is possible to update the BlueOS-bootstrap image to match the BlueOS release through the [BlueOS Version](../../advanced-usage#blueos-version) chooser, and is the recommended process.
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Getting Started"
 description = "BlueOS getting started instructions."
-date = 2023-02-23T23:15:00+11:00
+date = 2023-12-04T20:00:00+11:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 20
@@ -71,9 +71,12 @@ For more details see the Advanced Usage [Interface Overview](../advanced-usage/#
 
 BlueOS supports [multiple release types](../overview/#release-types) - we recommend the latest stable version for most people. Releases and change-logs are available on the [GitHub releases page](https://github.com/bluerobotics/blueos-docker/releases).
 
-### Connect Wifi
+### Connect Internet
 
-When starting out, it's important to connect to wifi so you can update to the latest suitable release.
+When starting out, it's important to connect your vehicle to the internet so you can update to the latest suitable release.
+Internet connectivity is possible via either [wifi](#connect-wifi) or [passed through a tether](#tether-passthrough).
+
+#### Connect Wifi
 
 1. First, click the wifi indicator to scan for available wifi networks
 
@@ -84,6 +87,17 @@ When starting out, it's important to connect to wifi so you can update to the la
 1. Once connected, the wifi icon will change to show the signal strength, and the connected wifi network will be selected on the menu
 
    ![Wifi Confirm](wifi-confirm.png)
+
+#### Tether Passthrough
+
+- [macOS instructions](https://support.apple.com/en-au/guide/mac-help/mchlp1540/mac)
+- [Windows instructions](https://pureinfotech.com/share-internet-connection-windows-10/)
+   - [Windows 10 troubleshooting](https://discuss.bluerobotics.com/t/windows-10-cellular-while-flying-rov/14816)
+- [Ubuntu (Linux) instructions](https://unix.stackexchange.com/questions/575178/sharing-wifi-internet-through-ethernet-interface)
+- [Arch (Linux) instructions](https://wiki.archlinux.org/title/Internet_sharing)
+
+Once the internet passthrough has been configured, the BlueOS header should 
+[show that it has internet connectivity](../advanced-usage/#internet-status-and-management).
 
 ### Select Version
 


### PR DESCRIPTION
Some small improvements.

Most of them can be back-ported to `BlueOS-1.1` and `BlueOS-beta` immediately, but the mDNS docs can't because [the USB-OTG fix](https://github.com/bluerobotics/BlueOS/pull/2150) is currently only in the `master` branch of BlueOS (it hasn't been ported to `1.1` yet, and isn't yet in a beta release).