### PR TITLE
[main] `Cockpit-0.0` -> `Cockpit-1.0`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	path = content/integrations
 	url = https://github.com/bluerobotics/ardusub-zola
 	branch = Integrations
-[submodule "content/software/control-station/Cockpit-0.0"]
-	path = content/software/control-station/Cockpit-0.0
+[submodule "content/software/control-station/Cockpit-1.0"]
+	path = content/software/control-station/Cockpit-1.0
 	url = https://github.com/bluerobotics/ardusub-zola
-	branch = Cockpit-0.0
+	branch = Cockpit-1.0


### PR DESCRIPTION
`Cockpit-0.0` was only relevant while in alpha - we don't actually want docs for it. Now that the 1.0 beta is released, switch to using `Cockpit-1.0` instead.