### PR TITLE
[BlueOS-beta] development: extensions: remove unused redirect

### DIFF
--- a/development/extensions/index.md
+++ b/development/extensions/index.md
@@ -6,7 +6,7 @@ template = "docs/page.html"
 sort_by = "weight"
 weight = 40
 draft = false
-aliases = ['software/onboard/BlueOS-latest/development/extensions', 'software/onboard/BlueOS-latest/extensions', 'software/onboard/BlueOS-1.1/extensions', '/blueos/latest/development/extensions']
+aliases = ['software/onboard/BlueOS-latest/development/extensions', 'software/onboard/BlueOS-latest/extensions', '/blueos/latest/development/extensions']
 
 [extra]
 lead = ''


### PR DESCRIPTION
Avoids new branches trying to take a redirect that's owned by `BlueOS-1.1`.

Multiple destinations for the same redirect cause Zola building to fail.